### PR TITLE
Changed LogStashFormatter to take type from progname, which has the h…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kenny (0.1.2)
+    kenny (0.1.4)
       actionmailer (~> 4.2)
       actionpack (~> 4.2)
       activerecord (~> 4.2)

--- a/README.md
+++ b/README.md
@@ -152,3 +152,7 @@ Or command line:
   Apart from subscribing to instrumentation events and logging, Kenny also provides formatters, which you can attach to a logger.
 
   Currently, it only comes with a LogStashFormatter, but feel free to add more Formatters to make this project great.
+
+## Release Notes
+  *Version 0.1.4*: LogStashFormatter can take a `type` attribute through the logger's progname. If that is nil, it falls back to the message-hash's `['type']`. If they are all nil, then `type` can still be set through FileBeat's config.
+

--- a/kenny.gemspec
+++ b/kenny.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 Gem::Specification.new do |spec|
   spec.name = 'kenny'
-  spec.version = '0.1.3'
+  spec.version = '0.1.4'
   spec.authors = ['Mathias Rüdiger', 'Alex Fong']
   spec.email = ['mathias.ruediger@fromatob.com', 'alex.fong@fromatob.com']
 

--- a/lib/kenny/formatters/log_stash_formatter.rb
+++ b/lib/kenny/formatters/log_stash_formatter.rb
@@ -4,22 +4,19 @@ require 'active_support'
 
 module Kenny
   module Formatters
+    ##
     # Formats messages as LogStash::Event
+    # the 'type' field can be used for ElasticSearch
+    # The 'type' could be set through the Logger's progname,
+    # which takes the highest precedence.
+    # If logger.progname.nil?, it will take the 'type' within the hash.
+    # If the 'type' within the Hash is also nil,
+    # then you can set the type through FileBeat's config
     class LogStashFormatter < ::Logger::Formatter
-      include ActiveSupport::TaggedLogging::Formatter
-
       def call(severity, time, progname, msg)
         msg = { 'message' => msg.is_a?(String) ? msg : msg.inspect } unless msg.is_a?(Hash)
-
         msg['severity'] = severity if severity
-        msg['progname'] = progname if progname
-
-        tags = current_tags
-
-        if tags.any?
-          msg['type'] ||= tags.first
-          msg['tags'] = tags
-        end
+        msg['type'] = progname if progname
 
         event = LogStash::Event.new(msg)
 

--- a/spec/formatters/logstash_formatter_spec.rb
+++ b/spec/formatters/logstash_formatter_spec.rb
@@ -7,12 +7,11 @@ RSpec.describe Kenny::Formatters::LogStashFormatter do
 
     let(:strio) { StringIO.new }
     let(:logger) { ActiveSupport::Logger.new(strio) }
-    let(:tagged_logger) { ActiveSupport::TaggedLogging.new(logger) }
 
-    context 'when not using tags' do
+    context 'progname not set in logger' do
       before do
-        tagged_logger.formatter = Kenny::Formatters::LogStashFormatter.new
-        tagged_logger.info log_input
+        logger.formatter = Kenny::Formatters::LogStashFormatter.new
+        logger.info log_input
       end
 
       context 'and logging a string' do
@@ -25,50 +24,63 @@ RSpec.describe Kenny::Formatters::LogStashFormatter do
         it 'has a correct timestamp' do
           expect(Time.parse(subject['@timestamp'])).to be_within(2).of Time.now
         end
+
+        it { expect(subject['type']).to be_nil }
       end
 
       context 'and logging an object' do
-        let(:log_input) { { type: 'foo', test: 123 } }
+        context 'type set in hash' do
+          let(:log_input) { { type: 'foo', test: 123 } }
 
-        it 'contains the data in the correct field' do
-          expect(subject['test']).to eq 123
-        end
+          it 'contains the data in the correct field' do
+            expect(subject['test']).to eq 123
+          end
 
-        it 'has a correct timestamp' do
-          expect(Time.parse(subject['@timestamp'])).to be_within(2).of Time.now
-        end
+          it 'has a correct timestamp' do
+            expect(Time.parse(subject['@timestamp'])).to be_within(2).of Time.now
+          end
 
-        it 'has a field type containing the type' do
-          expect(subject['type']).to eq 'foo'
-        end
-      end
-    end
-
-    context 'when using tags' do
-      before do
-        tagged_logger.formatter = Kenny::Formatters::LogStashFormatter.new
-        tagged_logger.tagged('test_type') do
-          tagged_logger.tagged('test_tag') do
-            tagged_logger.info 'foobar'
+          it 'has a field type containing the type' do
+            expect(subject['type']).to eq 'foo'
           end
         end
-      end
 
-      it 'uses the string as message' do
-        expect(subject['message']).to eq 'foobar'
-      end
+        context 'type NOT set in hash' do
+          let(:log_input) { { test: 123 } }
 
-      it 'has a correct timestamp' do
-        expect(Time.parse(subject['@timestamp'])).to be_within(2).of Time.now
-      end
-
-      it 'has the correct type' do
-        expect(subject['type']).to eq 'test_type'
-      end
-
-      it 'has the correct tags' do
-        expect(subject['tags']).to eq %w(test_type test_tag)
+          it { expect(subject['type']).to be_nil }
+        end
       end
     end
+
+    context 'progname has been set in logger' do
+      before do
+        logger.formatter = Kenny::Formatters::LogStashFormatter.new
+        logger.progname = 'aspector'
+        logger.info log_input
+      end
+
+      context 'logging a string' do
+        let(:log_input) { 'hello world' }
+        it 'uses the progname as type' do
+          expect(subject['type']).to eq 'aspector'
+        end
+      end
+
+      context 'logging a Hash without type in it' do
+        let(:log_input) { { test: 123 } }
+        it 'uses the logger.progname as type' do
+          expect(subject['type']).to eq 'aspector'
+        end
+      end
+
+      context 'logging a Hash with type in it' do
+        let(:log_input) { { type: 'foo', test: 123 } }
+        it 'gives progname precedence over type within the hash' do
+          expect(subject['type']).to eq 'aspector'
+        end
+      end
+    end
+
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,7 @@ def dummy_kenny_configs
       {
         name: 'process_action.action_controller',
         block: lambda do |event|
-          Date.parse "2016-01-01"
+          Date.parse '2016-01-01'
           logger.info(event.inspect)
         end,
         logger: request_logger


### PR DESCRIPTION
…ighest precedence.

1 'type' from logger.progname has the highest precedence
2 If that is empty, it takes the value from the hash's ['type']
3 If none of the above is set, type can be set through FileBeat config